### PR TITLE
Adds the `include_external_user_ids` parameter to device notifications

### DIFF
--- a/documentation/guide/device-notification.md
+++ b/documentation/guide/device-notification.md
@@ -28,5 +28,6 @@ client.send(notification_to_users)
 - include_chrome_reg_ids
 - include_chrome_web_reg_ids
 - include_android_reg_ids
+- include_external_user_ids
 
 [More details](https://documentation.onesignal.com/reference#section-send-to-specific-devices)

--- a/onesignal/device_notification.py
+++ b/onesignal/device_notification.py
@@ -15,6 +15,7 @@ class DeviceNotification(Notification):
         include_chrome_reg_ids
         include_chrome_web_reg_ids
         include_android_reg_ids
+        include_external_user_ids
         {common_notification_paramenters}
     """.format(common_notification_paramenters=common_notification_paramenters)
 
@@ -28,6 +29,7 @@ class DeviceNotification(Notification):
                  include_chrome_reg_ids=None,
                  include_chrome_web_reg_ids=None,
                  include_android_reg_ids=None,
+                 include_external_user_ids=None,
                  **kwargs):
         Notification.__init__(self, **kwargs)
         self.include_player_ids = include_player_ids
@@ -39,6 +41,7 @@ class DeviceNotification(Notification):
         self.include_chrome_reg_ids = include_chrome_reg_ids
         self.include_chrome_web_reg_ids = include_chrome_web_reg_ids
         self.include_android_reg_ids = include_android_reg_ids
+        self.include_external_user_ids = include_external_user_ids
 
     def get_data(self):
         return merge_dicts(
@@ -52,6 +55,7 @@ class DeviceNotification(Notification):
                 "include_amazon_reg_ids": self.include_amazon_reg_ids,
                 "include_chrome_reg_ids": self.include_chrome_reg_ids,
                 "include_chrome_web_reg_ids": self.include_chrome_web_reg_ids,
-                "include_android_reg_ids": self.include_android_reg_ids
+                "include_android_reg_ids": self.include_android_reg_ids,
+                "include_external_user_ids": self.include_external_user_ids
             }
         )


### PR DESCRIPTION
This is parameter is mentioned in the documentation [1] but not implemented. I didn't generate the doc folder new as this changed every file as the file naming changed and polluted the commit. 

[1] https://documentation.onesignal.com/reference#section-send-to-specific-devices