### PR TITLE
Fixed `local variable referenced before assignment` exception thrown due to passing unicode API_KEYs

### DIFF
--- a/onesignal/core.py
+++ b/onesignal/core.py
@@ -59,6 +59,7 @@ class OneSignal:
         Returns:
             A dict of the API response
         """
+        # Allow unicode app ID, Python 3 doesn't support basestring
         try:
             basestring
         except NameError:

--- a/onesignal/core.py
+++ b/onesignal/core.py
@@ -59,6 +59,10 @@ class OneSignal:
         Returns:
             A dict of the API response
         """
+        try:
+            basestring
+        except NameError:
+            basestring = str
 
         if isinstance(self.app_id, basestring):
             app_id_obj = {"app_id": self.app_id}

--- a/onesignal/core.py
+++ b/onesignal/core.py
@@ -60,7 +60,7 @@ class OneSignal:
             A dict of the API response
         """
 
-        if isinstance(self.app_id, str):
+        if isinstance(self.app_id, basestring):
             app_id_obj = {"app_id": self.app_id}
         elif isinstance(self.app_id, list):
             app_id_obj = {"app_ids": self.app_id}


### PR DESCRIPTION
When reading the api key from a config file I found out that when passing a unicode API key an exception is thrown when trying to send notifications and the notifications cannot be sent.

The exact exception is:
`local variable 'app_id_obj' referenced before assignment`